### PR TITLE
New config-API-features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog contains mostly API-Changes and changes for developers.
 
+## v3.6.1
+* Support for configuration-example-file `content.elementToggle` toggle to improve UX in the SCNX Dashboard
+
 ## v3.5.0
 * Like ten new previously closed-sourced-modules got added
 * Locales-Loading now takes place in splitted files, instead of a big `default-locales.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 This changelog contains mostly API-Changes and changes for developers.
 
-## v3.6.1
-* Support for configuration-example-file `content.elementToggle` toggle to improve UX in the SCNX Dashboard
+## v3.6.0
+* Support for configuration-example-file `content.elementToggle` toggle to improve UX in the SCNX Dashboard ([#76](https://github.com/SCNetwork/CustomDCBot/pull/76))
+* Support for configuration-example-file `content.dependsOn` toggle to improve UX in the SCNX Dashboard ([#76](https://github.com/SCNetwork/CustomDCBot/pull/76))
+* Support for new field-types: `userID`, `imgURL` ([#76](https://github.com/SCNetwork/CustomDCBot/pull/76))
+* Moderation-Modul: Support for Channel-Mutes ([#77](https://github.com/SCNetwork/CustomDCBot/pull/77))
+* Channel-Stats-Modul: Support for userWithRole parameters ([#78](https://github.com/SCNetwork/CustomDCBot/pull/78))
 
 ## v3.5.0
 * Like ten new previously closed-sourced-modules got added

--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ An example config file should include the following things:
           of an embed (only if `allowEmbed` is enabled)
     * `allowNull` (default: `false`, optional): If the value of this field can be empty
     * `disableKeyEdits` (if type === `keyed`): If enabled the user can not edit the keys of the object
-    * `elementToggle` (if type === `boolean`): If this option gets turned of, other fields of the config-element / file will not be rendered in the dashboard
+    * `elementToggle` (if type === `boolean`): If this option gets turned off, other fields of the config-element / file will not be rendered in the dashboard
+    * `dependsOn` (a name of any (other) boolean-field): If the referenced boolean field (the value of this option should be equal to the `field.field_name` of a boolean field) is turned off, the field will be not be rendered in the dashboard
 
 #### `botReady`-Event and Config-Reload
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,18 @@ information about that in [this issue](https://github.com/SCNetwork/CustomDCBot/
 
 As mentioned above our business model is to host these bots for servers - it does not really make sense to publish our
 product here - but we do it anyway - but we need your support! Feel free to [contribute](.github/CONTRIBUTING.md)
-, [get a membership](https://membership.sc-network.net) (also on [Patreon](https://patreon.com/scnetwork)), or donate [via Creditcard](https://scnx.app/scam) or [PayPal](https://paypal.me/therealscderox). Thank you so much <3
+, [get a membership](https://membership.sc-network.net) (also on [Patreon](https://patreon.com/scnetwork)), or
+donate [via Creditcard](https://scnx.app/scam) or [PayPal](https://paypal.me/therealscderox). Thank you so much <3
 
 ## Need help?
-Are you stuck? Please do not ask on our Discord (unless you are using our hosted version), instead ask in the [discussions-tab](https://github.com/SCNetwork/CustomDCBot/discussions). 
+
+Are you stuck? Please do not ask on our Discord (unless you are using our hosted version), instead ask in
+the [discussions-tab](https://github.com/SCNetwork/CustomDCBot/discussions).
 
 ## Need something even more custom?
-We are happy to give you a quote for individual requirements. Please email `sales@sc-network.net` with your requirements.  
+
+We are happy to give you a quote for individual requirements. Please email `sales@sc-network.net` with your
+requirements.
 
 ### Table of contents
 
@@ -207,7 +212,8 @@ An interaction-command ("slash command") file has to export the following things
     * `description`: Description of the command
     * `restricted`: Can this command only be run one of the bot operators (e.g. config reloading, change status or ...,
       boolean)
-    * `defaultPermission`: Boolean (default: true): If enabled everyone on the guild can use this command and your command's permissions can not be synced
+    * `defaultPermission`: Boolean (default: true): If enabled everyone on the guild can use this command and your
+      command's permissions can not be synced
     * `options`:
         * [ApplicationCommandOptionData](https://discord.js.org/#/docs/main/stable/typedef/ApplicationCommandOptionData)
           OR
@@ -272,7 +278,7 @@ An example config file should include the following things:
     * `field_name`: Name of the config field
     * `default-<lang>`: Default value of this field (replace `<lang>` with a supported language code),
       Fallback-Order: `default-<lang>`, `default-en`, `default`
-    * `type`: Can be `channelID`, `select`, `timezone` (treated as string, please check validity before using), `roleID`
+    * `type`: Can be `channelID`, `userID`, `select`, `timezone` (treated as string, please check validity before using), `roleID`
       , `boolean`, `integer`, `array`, `keyed` (codename for an JS-Object)
       or `string`
     * `description-<lang>`: Description of this field (replace `<lang>` with a supported language code),

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ An example config file should include the following things:
     * `field_name`: Name of the config field
     * `default-<lang>`: Default value of this field (replace `<lang>` with a supported language code),
       Fallback-Order: `default-<lang>`, `default-en`, `default`
-    * `type`: Can be `channelID`, `userID`, `select`, `timezone` (treated as string, please check validity before using), `roleID`
+    * `type`: Can be `channelID`, `userID`, `imgURL`, `select`, `timezone` (treated as string, please check validity before using), `roleID`
       , `boolean`, `integer`, `array`, `keyed` (codename for an JS-Object)
       or `string`
     * `description-<lang>`: Description of this field (replace `<lang>` with a supported language code),

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ An example config file should include the following things:
         * `isImage`: If true, users will be able to set this parameter as Image, Author-Icon, Footer-Icon or Thumbnail
           of an embed (only if `allowEmbed` is enabled)
     * `allowNull` (default: `false`, optional): If the value of this field can be empty
-    * `disableKeyEdits` (if type === `keyed`): If enabled the user is not allowed to change the keys of this element
+    * `disableKeyEdits` (if type === `keyed`): If enabled the user can not edit the keys of the object
+    * `elementToggle` (if type === `boolean`): If this option gets turned of, other fields of the config-element / file will not be rendered in the dashboard
 
 #### `botReady`-Event and Config-Reload
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -66,6 +66,7 @@
         "moduleconf-regeneration": "Modul-Konfiguration wird regeniert, es werden keine Einstellungen überschrieben.",
         "moduleconf-regeneration-success": "Module-Konfiguration wurde regeniert.",
         "channel-not-found": "Kanal mit ID \"%id\" wurde nicht gefunden",
+        "user-not-found": "Discord-Account mit ID \"%id\" wurde nicht gefunden",
         "channel-not-on-guild": "Kanal mit ID \"%id\" ist nicht auf deinem Server",
         "role-not-found": "Rolle mit ID \"%id\" wurde nicht auf deinem Server gefunden",
         "config-reload": "Gesamte Konfiguration wird neugeladen...",

--- a/locales/en.json
+++ b/locales/en.json
@@ -64,6 +64,7 @@
     "moduleconf-regeneration": "Regenerating module configuration, no settings will be overwritten, don't worry.",
     "moduleconf-regeneration-success": "Module configuration regeneration successfully finished.",
     "channel-not-found": "Channel with ID \"%id\" could not be found",
+    "user-not-found": "Discord-User with ID \"%id\" could not be found",
     "channel-not-on-guild": "Channel with ID \"%id\" is not on your guild",
     "channel-invalid-type": "Channel with ID \"%id\" has a type that can not be used for this field",
     "role-not-found": "Role with ID \"%id\" could not be found on your guild",

--- a/modules/fun/config.json
+++ b/modules/fun/config.json
@@ -132,7 +132,7 @@
         "https://media1.tenor.com/images/fd47e55dfb49ae1d39675d6eff34a729/tenor.gif?itemid=12687187"
       ],
       "type": "array",
-      "content": "string",
+      "content": "imgURL",
       "humanname-de": "Umarmungsbilder",
       "description-de": "Bilder aus welchen, wenn jemand /hug ausführt, zufällig ausgewählt wird",
       "params-de": {},
@@ -189,7 +189,7 @@
         "https://media1.tenor.com/images/78095c007974aceb72b91aeb7ee54a71/tenor.gif?itemid=5095865"
       ],
       "type": "array",
-      "content": "string",
+      "content": "imgURL",
       "humanname-de": "Kussbilder",
       "description-de": "Bilder aus welchen, wenn jemand /kiss ausführt, zufällig ausgewählt wird",
       "params-de": {},
@@ -248,7 +248,7 @@
         "https://media1.tenor.com/images/03ea2379718496fbbd144c5bc50f8e96/tenor.gif?itemid=18908545"
       ],
       "type": "array",
-      "content": "string",
+      "content": "imgURL",
       "humanname-de": "Schlag-Bilder",
       "description-de": "Bilder aus welchen, wenn jemand /slap ausführt, zufällig ausgewählt wird",
       "params-de": {},
@@ -308,7 +308,7 @@
         "https://media1.tenor.com/images/be0c22e0af951aa7fa8753381663eb2c/tenor.gif?itemid=15824856"
       ],
       "type": "array",
-      "content": "string",
+      "content": "imgURL",
       "humanname-de": "Tätschel-Bilder",
       "description-de": "Bilder aus welchen, wenn jemand /pat ausführt, zufällig ausgewählt wird",
       "params-de": {},

--- a/modules/moderation/configs/antiJoinRaid.json
+++ b/modules/moderation/configs/antiJoinRaid.json
@@ -9,7 +9,8 @@
       "humanname-de": "Aktiviert",
       "description-de": "Aktiviert oder deaktiviert das Anti-Join-Raid-System",
       "params-de": {},
-      "default-de": true
+      "default-de": true,
+      "elementToggle": true
     },
     {
       "field_name": "timeframe",

--- a/modules/moderation/configs/antiSpam.json
+++ b/modules/moderation/configs/antiSpam.json
@@ -9,7 +9,8 @@
       "humanname-de": "Aktiviert",
       "description-de": "Aktiviert oder deaktiviert das Anti-Spam-System",
       "params-de": {},
-      "default-de": true
+      "default-de": true,
+      "elementToggle": true
     },
     {
       "field_name": "timeframe",

--- a/modules/moderation/configs/joinGate.json
+++ b/modules/moderation/configs/joinGate.json
@@ -9,7 +9,8 @@
       "humanname-de": "Aktiviert?",
       "description-de": "Aktiviere oder deaktiviere das Join-Gate",
       "params-de": {},
-      "default-de": true
+      "default-de": true,
+      "elementToggle": true
     },
     {
       "field_name": "allUsers",

--- a/modules/moderation/configs/verification.json
+++ b/modules/moderation/configs/verification.json
@@ -9,7 +9,8 @@
       "humanname-de": "",
       "description-de": "",
       "params-de": {},
-      "default-de": false
+      "default-de": false,
+      "elementToggle": true
     },
     {
       "field_name": "verification-needed-role",

--- a/modules/tickets/config.json
+++ b/modules/tickets/config.json
@@ -93,6 +93,7 @@
       "allowEmbed": true,
       "description-de": "Diese Nachricht wird an den Nutzer gesendet, wenn die entsprechende Option aktiviert ist",
       "description-en": "This message gets send to the user if sendUserDMAfterTicketClose is enabled",
+      "dependsOn": "sendUserDMAfterTicketClose",
       "params-de": [
         {
           "name": "%transcriptURL%",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customdcbot",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "Create your own discord bot - Fully customizable and with a lot of features",
   "main": "main.js",
   "repository": {

--- a/src/functions/configuration.js
+++ b/src/functions/configuration.js
@@ -160,7 +160,7 @@ async function checkModuleConfig(moduleName, afterCheckEventFile = null) {
                     }
                     if (field.disableKeyEdits) {
                         for (const content in configElement[field.field_name]) {
-                            if (!field.default[content]) {
+                            if (typeof field.default[content] === 'undefined') {
                                 delete configElement[field.field_name][content];
                                 ow = true;
                             }
@@ -294,6 +294,13 @@ async function checkType(type, value, contentFormat = null, allowEmbed = false) 
                 if (!errored) errored = !(await checkType(contentFormat, v, null, allowEmbed));
             }
             return !errored;
+        case 'userID':
+            const user = await client.users.fetch(value).catch(() => {});
+            if (!user) {
+                logger.error(localize('config', 'user-not-found', {id: value}));
+                return false;
+            }
+            return true;
         case 'channelID':
             const channel = await client.channels.fetch(value).catch(() => {
             });

--- a/src/functions/configuration.js
+++ b/src/functions/configuration.js
@@ -129,6 +129,7 @@ async function checkModuleConfig(moduleName, afterCheckEventFile = null) {
                     }
                     if (typeof configElement[field.field_name] === 'undefined') {
                         configElement[field.field_name] = field.default;
+                        ow = true;
                         return res(configElement);
                     } else if (field.type === 'keyed' && field.disableKeyEdits) {
                         for (const key in field.default) {

--- a/src/functions/configuration.js
+++ b/src/functions/configuration.js
@@ -284,6 +284,7 @@ async function checkType(type, value, contentFormat = null, allowEmbed = false) 
             if (parseInt(value) === 0) return true;
             return !!parseInt(value);
         case 'string':
+        case 'imgURL':
         case 'timezone': // Timezones can not be checked correctly for their type currently.
             if (allowEmbed && typeof value === 'object') return true;
             return typeof value === 'string';


### PR DESCRIPTION
To improve the user experience in the SCNX Dashboard, several new API-Features for config-example-files are planned. 

Currently new features:
* content.elementToggle: Hides all other fields of the Config-Element (/file) in the Dashboard if disabled. [Demo](https://user-images.githubusercontent.com/43812987/194376419-38772088-bd8c-40a0-866a-5d00348c449c.mp4).
* content.dependsOn: References an other boolean-field. If the referenced field is disabled, this field will get hidden. [Demo](https://user-images.githubusercontent.com/43812987/194622438-5d7ccae9-2088-4900-8d31-fecc9a5357f9.mp4) 
* New field-type: `userID` ([Demo](https://user-images.githubusercontent.com/43812987/194871559-b53c4243-eb24-4ef4-ae4e-4fe4bfd86585.png))
* New field-type: `imgURL` ([Demo](https://user-images.githubusercontent.com/43812987/194880821-6e8fe34a-32a1-4d6a-81de-74ebfa5d3803.png))


This PR is WIP, meaning new fields may get added later.

Feel free to comment features you'd 

like to see in the Dashboard for config-example-files.


