### PR TITLE
Sticky messages setting to allow responses to bots

### DIFF
--- a/modules/sticky-messages/configs/sticky-messages.json
+++ b/modules/sticky-messages/configs/sticky-messages.json
@@ -40,6 +40,20 @@
 			},
 			"type": "string",
 			"allowEmbed": true
+		},{
+			"name": "respondBots",
+			"humanName": {
+				"en": "Respond to bots",
+				"de": "Antworten auf Bots"
+			},
+			"default": {
+				"en": false
+			},
+			"description": {
+				"en": "Whether your bot reacts to messages from other bots in the channel",
+				"de": "Ob dein Bot auf Nachrichten von anderen Bots in dem Kanal reagiert"
+			},
+			"type": "boolean"
 		}
 	]
 }

--- a/modules/sticky-messages/events/messageCreate.js
+++ b/modules/sticky-messages/events/messageCreate.js
@@ -43,13 +43,14 @@ module.exports.run = async (client, msg) => {
     if (!msg.guild) return;
     if (msg.guild.id !== client.guildID) return;
     if (!msg.member) return;
-    if (msg.author.bot) return;
+    if (msg.author.id === client.user.id) return;
 
     const stickyChannels = client.configurations['sticky-messages']['sticky-messages'];
     if (!stickyChannels) return;
 
     const currentConfig = stickyChannels.find(c => c.channelId === msg.channel.id);
     if (!currentConfig || !currentConfig.message) return;
+    if (!currentConfig.respondBots && msg.author.bot) return;
 
     if (channelData[msg.channel.id]) {
         if (channelData[msg.channel.id].time + 5000 > Date.now()) {

--- a/modules/sticky-messages/events/messageCreate.js
+++ b/modules/sticky-messages/events/messageCreate.js
@@ -1,5 +1,6 @@
 const { embedTypeV2 } = require('../../../src/functions/helpers');
 const channelData = {};
+let isSending = false;
 
 /**
  * Deletes the sticky message sent by the bot
@@ -24,17 +25,20 @@ module.exports.deleteMessage = deleteMessage;
  * @param {Object|String} configMsg The configured message
  */
 async function sendMessage(channel, configMsg) {
+    isSending = true;
     channelData[channel.id] = {
         msg: null,
         timeout: null,
         time: Date.now()
     };
+
     const sentMessage = await channel.send(await embedTypeV2(configMsg));
     channelData[channel.id] = {
         msg: sentMessage.id,
         timeout: null,
         time: Date.now()
     };
+    isSending = false;
 }
 module.exports.sendMessage = sendMessage;
 
@@ -43,7 +47,7 @@ module.exports.run = async (client, msg) => {
     if (!msg.guild) return;
     if (msg.guild.id !== client.guildID) return;
     if (!msg.member) return;
-    if (msg.author.id === client.user.id) return;
+    if (msg.author.id === client.user.id && isSending) return;
 
     const stickyChannels = client.configurations['sticky-messages']['sticky-messages'];
     if (!stickyChannels) return;


### PR DESCRIPTION
Small change to allow enabling responding to other bots per sticky message.
The current bot still gets ignored to prevent reacting to itself.