### PR TITLE
Welcomer: Fixed issue with duplicated message parameter

### DIFF
--- a/modules/welcomer/configs/channels.json
+++ b/modules/welcomer/configs/channels.json
@@ -85,10 +85,6 @@
         {
           "name": "guildLevel",
           "description": "Boost-Level of the guild after the boost"
-        },
-        {
-          "name": "mention",
-          "description": "Mention of the user who unboosted"
         }
       ]
     },


### PR DESCRIPTION
Hey, regarding to the support ticket (ID: 1534784220763914320) I removed the duplicated parameter (since the %mention% parameter is used for every case, even for unboosting) 🙂